### PR TITLE
Adds Hardmode Item Option

### DIFF
--- a/worlds/terraria/Options.py
+++ b/worlds/terraria/Options.py
@@ -78,6 +78,13 @@ class FillExtraChecksWith(Choice):
     option_useful_items = 1
     default = 1
 
+class ReceiveHardmodeAsItem(Toggle):
+    """
+    If set to true, receiving Hardmode gives you an item that allows you to start Hardmode manually.
+    """
+
+    display_name = "Receive Hardmode as Item"
+    default = 1
 
 @dataclass
 class TerrariaOptions(PerGameCommonOptions):
@@ -89,4 +96,5 @@ class TerrariaOptions(PerGameCommonOptions):
     grindy_achievements: GrindyAchievements
     fishing_achievements: FishingAchievements
     fill_extra_checks_with: FillExtraChecksWith
+    receive_hardmode_as_item: ReceiveHardmodeAsItem
     death_link: DeathLink

--- a/worlds/terraria/__init__.py
+++ b/worlds/terraria/__init__.py
@@ -371,4 +371,5 @@ class TerrariaWorld(World):
             "normal_achievements": self.options.normal_achievements.value,
             "grindy_achievements": self.options.grindy_achievements.value,
             "fishing_achievements": self.options.fishing_achievements.value,
+            "receive_hardmode_as_item": self.options.receive_hardmode_as_item.value
         }


### PR DESCRIPTION
### What is this fixing or adding?
This is intended as a very simple emulation of the Hardmode Clique Plando thing people do so they can activate Hardmode at their own leisure.
CLIENTSIDE: Adds an item called the "Hardmode Starter" into the code; it's a consumable item that triggers Hardmode on use and nothing more.
WORLDSIDE: Adds an option to enable or disable receiving Hardmode as an item, and adds that option's value into the slot data.
### How was this tested?
Generated a solo world and activated the check to ensure the player receives the item, then exited the game and logged back in to ensure it was properly added into the Buyback Shop.
